### PR TITLE
Fix README.md package to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ import (
         "context"
 
         "github.com/nifcloud/nifcloud-sdk-go/nifcloud"
-        "github.com/nifcloud/nifcloud-sdk-go/nifcloud/endpoints"
         "github.com/nifcloud/nifcloud-sdk-go/service/computing"
 )
 


### PR DESCRIPTION
### Summary

- fix package to import
- "github.com/nifcloud/nifcloud-sdk-go/nifcloud/endpoints" is not used

### Test

- [x] check no problems