### PR TITLE
Fix to stop the NASInstanceAvailable waiter when target NAS instance state is failed

### DIFF
--- a/models/apis/nas/N2016-02-24/waiters-2.json
+++ b/models/apis/nas/N2016-02-24/waiters-2.json
@@ -29,6 +29,12 @@
           "expected": "available",
           "state": "success",
           "argument": "NASInstances[].NASInstanceStatus"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "failed",
+          "state": "failure",
+          "argument": "NASInstances[].NASInstanceStatus"
         }
       ]
     },

--- a/service/nas/api_waiters.go
+++ b/service/nas/api_waiters.go
@@ -29,6 +29,11 @@ func (c *Client) WaitUntilNASInstanceAvailable(ctx context.Context, input *Descr
 				Matcher: aws.PathAllWaiterMatch, Argument: "NASInstances[].NASInstanceStatus",
 				Expected: "available",
 			},
+			{
+				State:   aws.FailureWaiterState,
+				Matcher: aws.PathAllWaiterMatch, Argument: "NASInstances[].NASInstanceStatus",
+				Expected: "failed",
+			},
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []aws.Option) (*aws.Request, error) {


### PR DESCRIPTION
# Summary

- Fix to stop the NASInstanceAvailable waiter when target NAS instance state is failed.

# Tests

- [x] LGTM