### PR TITLE
Fix hatoba LoadBalancing

### DIFF
--- a/codegen/sdk-codegen/nifcloud-models/hatoba.smithy
+++ b/codegen/sdk-codegen/nifcloud-models/hatoba.smithy
@@ -48,10 +48,10 @@ structure Cluster {
 
 structure AddonsConfig {
     @jsonName("httpLoadBalancing")
-    HttpLoadBalancing: HttpLoadBalancingOfNiftyDescribeAutoScalingGroups,
+    HttpLoadBalancing: HttpLoadBalancing,
 }
 
-structure HttpLoadBalancingOfNiftyDescribeAutoScalingGroups {
+structure HttpLoadBalancing {
     @jsonName("disabled")
     Disabled: Boolean,
 }
@@ -213,14 +213,14 @@ list ListOfRequestLocations {
     member: String,
 }
 
-structure RequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups {
+structure RequestHttpLoadBalancing {
     @jsonName("disabled")
     Disabled: Boolean,
 }
 
 structure RequestAddonsConfig {
     @jsonName("httpLoadBalancing")
-    RequestHttpLoadBalancing: RequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups,
+    RequestHttpLoadBalancing: RequestHttpLoadBalancing,
 }
 
 structure RequestNodePools {

--- a/service/hatoba/deserializers.go
+++ b/service/hatoba/deserializers.go
@@ -4261,7 +4261,7 @@ func awsRestjson1_deserializeDocumentAddonsConfig(v **types.AddonsConfig, value 
 	for key, value := range shape {
 		switch key {
 			case "httpLoadBalancing":
-				if err := awsRestjson1_deserializeDocumentHttpLoadBalancingOfNiftyDescribeAutoScalingGroups(&sv.HttpLoadBalancing, value); err != nil {
+				if err := awsRestjson1_deserializeDocumentHttpLoadBalancing(&sv.HttpLoadBalancing, value); err != nil {
 					return err
 				}
 			
@@ -5201,7 +5201,7 @@ func awsRestjson1_deserializeDocumentHealthCheck(v **types.HealthCheck, value in
 	return nil
 }
 
-func awsRestjson1_deserializeDocumentHttpLoadBalancingOfNiftyDescribeAutoScalingGroups(v **types.HttpLoadBalancingOfNiftyDescribeAutoScalingGroups, value interface{}) error {
+func awsRestjson1_deserializeDocumentHttpLoadBalancing(v **types.HttpLoadBalancing, value interface{}) error {
 	if v == nil {
 		return fmt.Errorf("unexpected nil of type %T", v)
 	}
@@ -5214,9 +5214,9 @@ func awsRestjson1_deserializeDocumentHttpLoadBalancingOfNiftyDescribeAutoScaling
 		return fmt.Errorf("unexpected JSON type %v", value)
 	}
 	
-	var sv *types.HttpLoadBalancingOfNiftyDescribeAutoScalingGroups
+	var sv *types.HttpLoadBalancing
 	if *v == nil {
-		sv = &types.HttpLoadBalancingOfNiftyDescribeAutoScalingGroups{}
+		sv = &types.HttpLoadBalancing{}
 		} else {
 			sv = *v
 		}

--- a/service/hatoba/serializers.go
+++ b/service/hatoba/serializers.go
@@ -2027,7 +2027,7 @@ func awsRestjson1_serializeDocumentRequestAddonsConfig(v *types.RequestAddonsCon
 
 	if v.RequestHttpLoadBalancing != nil {
 		ok := object.Key("httpLoadBalancing")
-		if err := awsRestjson1_serializeDocumentRequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups(v.RequestHttpLoadBalancing, ok); err != nil {
+		if err := awsRestjson1_serializeDocumentRequestHttpLoadBalancing(v.RequestHttpLoadBalancing, ok); err != nil {
 			return err
 		}
 	}
@@ -2208,7 +2208,7 @@ func awsRestjson1_serializeDocumentRequestFirewallGroupOfUpdateFirewallGroup(v *
 	return nil
 }
 
-func awsRestjson1_serializeDocumentRequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups(v *types.RequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups, value smithyjson.Value) error {
+func awsRestjson1_serializeDocumentRequestHttpLoadBalancing(v *types.RequestHttpLoadBalancing, value smithyjson.Value) error {
 	object := value.Object()
 	defer object.Close()
 

--- a/service/hatoba/types/types.go
+++ b/service/hatoba/types/types.go
@@ -9,7 +9,7 @@ import (
 
 type AddonsConfig struct {
 	
-	HttpLoadBalancing *HttpLoadBalancingOfNiftyDescribeAutoScalingGroups
+	HttpLoadBalancing *HttpLoadBalancing
 	
 	noSmithyDocumentSerde
 }
@@ -206,7 +206,7 @@ type HealthCheck struct {
 	noSmithyDocumentSerde
 }
 
-type HttpLoadBalancingOfNiftyDescribeAutoScalingGroups struct {
+type HttpLoadBalancing struct {
 	
 	Disabled *bool
 	
@@ -482,7 +482,7 @@ type Option struct {
 
 type RequestAddonsConfig struct {
 	
-	RequestHttpLoadBalancing *RequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups
+	RequestHttpLoadBalancing *RequestHttpLoadBalancing
 	
 	noSmithyDocumentSerde
 }
@@ -572,7 +572,7 @@ type RequestFirewallGroupOfUpdateFirewallGroup struct {
 	noSmithyDocumentSerde
 }
 
-type RequestHttpLoadBalancingOfNiftyDescribeAutoScalingGroups struct {
+type RequestHttpLoadBalancing struct {
 	
 	Disabled *bool
 	


### PR DESCRIPTION
### Summary

- Fixed a bug for different spelling of `LoadBalancing` between Computing and Hatoba

### Test

- [x] :lemon: :accept: 