### PR TITLE
add config pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golangci/golangci-lint v1.51.1
 	github.com/jmespath/go-jmespath v0.4.0
 	golang.org/x/tools v0.5.0
+	gopkg.in/ini.v1 v1.67.0
 )
 
 require (
@@ -173,7 +174,6 @@ require (
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.4.0 // indirect

--- a/nifcloud/config/config.go
+++ b/nifcloud/config/config.go
@@ -1,0 +1,10 @@
+package config
+
+import (
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+)
+
+// LoadDefaultConfig the default configuration sources is environment variables
+func LoadDefaultConfig() (cfg nifcloud.Config) {
+	return LoadEnvConfig()
+}

--- a/nifcloud/config/env.go
+++ b/nifcloud/config/env.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"os"
+
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+)
+
+const (
+	nifcloudAccessKeyIDEnvVar     = "NIFCLOUD_ACCESS_KEY_ID"
+	nifcloudSecretAccessKeyEnvVar = "NIFCLOUD_SECRET_ACCESS_KEY"
+	nifcloudDefaultRegionEnvVar   = "NIFCLOUD_DEFAULT_REGION"
+)
+
+// LoadEnvConfig reads configuration values from the OS's environment variables
+func LoadEnvConfig() (cfg nifcloud.Config) {
+	return nifcloud.NewConfig(
+		os.Getenv(nifcloudAccessKeyIDEnvVar),
+		os.Getenv(nifcloudSecretAccessKeyEnvVar),
+		os.Getenv(nifcloudDefaultRegionEnvVar),
+	)
+}

--- a/nifcloud/config/shared.go
+++ b/nifcloud/config/shared.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/ini.v1"
+
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+)
+
+const (
+	defaultSharedConfigProfile = "default"
+	defaultSharedFileName      = ".nifcloud/credentials"
+
+	accessKeyIDKey  = "nifcloud_access_key_id"
+	secretAccessKey = "nifcloud_secret_access_key"
+	regionKey       = "region"
+)
+
+type LoadSharedConfigOptions struct {
+	Profile         string
+	CredentialsFile string
+}
+
+type LoadSharedConfigOption func(*LoadSharedConfigOptions)
+
+func LoadSharedConfigWithProfile(profile string) LoadSharedConfigOption {
+	return func(o *LoadSharedConfigOptions) {
+		o.Profile = profile
+	}
+}
+
+func LoadSharedConfigWithCredentialsFile(credentialsFile string) LoadSharedConfigOption {
+	return func(o *LoadSharedConfigOptions) {
+		o.CredentialsFile = credentialsFile
+	}
+}
+
+// LoadSharedConfig uses the configs passed in to load the SharedConfig from file
+func LoadSharedConfig(opts ...LoadSharedConfigOption) (nifcloud.Config, error) {
+	var opt LoadSharedConfigOptions
+	for _, fn := range opts {
+		fn(&opt)
+	}
+
+	if len(opt.Profile) == 0 {
+		opt.Profile = defaultSharedConfigProfile
+	}
+
+	if len(opt.CredentialsFile) == 0 {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nifcloud.Config{}, err
+		}
+		opt.CredentialsFile = filepath.Join(home, defaultSharedFileName)
+	}
+
+	sections, err := ini.Load(opt.CredentialsFile)
+	if err != nil {
+		return nifcloud.Config{}, err
+	}
+
+	section, err := sections.GetSection(opt.Profile)
+	if err != nil {
+		return nifcloud.Config{}, err
+	}
+
+	accsessKey, err := section.GetKey(accessKeyIDKey)
+	if err != nil {
+		return nifcloud.Config{}, err
+	}
+
+	secretKey, err := section.GetKey(secretAccessKey)
+	if err != nil {
+		return nifcloud.Config{}, err
+
+	}
+
+	region, err := section.GetKey(regionKey)
+	if err != nil {
+		return nifcloud.Config{}, err
+	}
+
+	return nifcloud.NewConfig(accsessKey.Value(), secretKey.Value(), region.Value()), nil
+}


### PR DESCRIPTION
### Summary

-  For easy config loading ,Add support from environment variables and files 🎉 

### Test

- [x] Enjoi 

```go
package main

import (
    "context"
    "fmt"

    "github.com/nifcloud/nifcloud-sdk-go/nifcloud"
    "github.com/nifcloud/nifcloud-sdk-go/nifcloud/config"
    "github.com/nifcloud/nifcloud-sdk-go/service/computing"
)

func main() {
    // Create config with credentials and region.
    cfg := config.LoadEnvConfig()

    // Create the Computing client with Config value.
    svc := computing.NewFromConfig(cfg)

    resp, err := svc.DescribeInstances(context.TODO(), nil)
    if err != nil {
        panic(err)
    }

    fmt.Println("Instances:")
    for _, reservationSet := range resp.ReservationSet {
        for _, instancesSet := range reservationSet.InstancesSet {
            fmt.Println(nifcloud.ToString(instancesSet.InstanceId))
        }
    }
}

```

```go
package main

import (
        "context"
        "fmt"

        "github.com/nifcloud/nifcloud-sdk-go/nifcloud"
        "github.com/nifcloud/nifcloud-sdk-go/nifcloud/config"
        "github.com/nifcloud/nifcloud-sdk-go/service/computing"
)

func main() {
        // Create config with credentials and region.
        cfg, err := config.LoadSharedConfig()
        if err != nil {
                panic(err)
        }

        // Create the Computing client with Config value.
        svc := computing.NewFromConfig(cfg)

        resp, err := svc.DescribeInstances(context.TODO(), nil)
        if err != nil {
                panic(err)
        }

        fmt.Println("Instances:")
        for _, reservationSet := range resp.ReservationSet {
                for _, instancesSet := range reservationSet.InstancesSet {
                        fmt.Println(nifcloud.ToString(instancesSet.InstanceId))
                }
        }
}

```