### PR TITLE
fix: GetBucketLifecycleConfiguration

### DIFF
--- a/codegen/sdk-codegen/nifcloud-models/storage.smithy
+++ b/codegen/sdk-codegen/nifcloud-models/storage.smithy
@@ -1576,9 +1576,14 @@ structure GetBucketLifecycleConfigurationRequest {
     Bucket: String,
 }
 
+list ListOfRule {
+    member: Rule,
+}
+
 structure GetBucketLifecycleConfigurationResult {
+    @xmlFlattened
     @xmlName("Rule")
-    Rule: Rule,
+    Rule: ListOfRule,
 }
 
 structure Rule {

--- a/nifcloud/go_module_metadata.go
+++ b/nifcloud/go_module_metadata.go
@@ -3,4 +3,4 @@
 package nifcloud
 
 // goModuleVersion is the tagged release for this module
-const goModuleVersion = "1.27.0"
+const goModuleVersion = "tip"

--- a/service/storage/api_op_GetBucketLifecycleConfiguration.go
+++ b/service/storage/api_op_GetBucketLifecycleConfiguration.go
@@ -36,7 +36,7 @@ type GetBucketLifecycleConfigurationInput struct {
 }
 
 type GetBucketLifecycleConfigurationOutput struct {
-	Rule *types.Rule
+	Rule []types.Rule
 
 	// Metadata pertaining to the operation's result.
 	ResultMetadata middleware.Metadata

--- a/service/storage/deserializers.go
+++ b/service/storage/deserializers.go
@@ -1857,7 +1857,7 @@ func awsRestxml_deserializeOpDocumentGetBucketLifecycleConfigurationOutput(v **G
 		switch {
 		case strings.EqualFold("Rule", t.Name.Local):
 			nodeDecoder := smithyxml.WrapNodeDecoder(decoder.Decoder, t)
-			if err := awsRestxml_deserializeDocumentRule(&sv.Rule, nodeDecoder); err != nil {
+			if err := awsRestxml_deserializeDocumentListOfRuleUnwrapped(&sv.Rule, nodeDecoder); err != nil {
 				return err
 			}
 
@@ -6858,6 +6858,74 @@ func awsRestxml_deserializeDocumentListOfPartUnwrapped(v *[]types.Part, decoder 
 		nodeDecoder := smithyxml.WrapNodeDecoder(decoder.Decoder, t)
 		destAddr := &mv
 		if err := awsRestxml_deserializeDocumentPart(&destAddr, nodeDecoder); err != nil {
+			return err
+		}
+		mv = *destAddr
+		sv = append(sv, mv)
+	}
+	*v = sv
+	return nil
+}
+func awsRestxml_deserializeDocumentListOfRule(v *[]types.Rule, decoder smithyxml.NodeDecoder) error {
+	if v == nil {
+		return fmt.Errorf("unexpected nil of type %T", v)
+	}
+	var sv []types.Rule
+	if *v == nil {
+		sv = make([]types.Rule, 0)
+	} else {
+		sv = *v
+	}
+
+	originalDecoder := decoder
+	for {
+		t, done, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if done {
+			break
+		}
+		switch {
+		case strings.EqualFold("member", t.Name.Local):
+			var col types.Rule
+			nodeDecoder := smithyxml.WrapNodeDecoder(decoder.Decoder, t)
+			destAddr := &col
+			if err := awsRestxml_deserializeDocumentRule(&destAddr, nodeDecoder); err != nil {
+				return err
+			}
+			col = *destAddr
+			sv = append(sv, col)
+
+		default:
+			err = decoder.Decoder.Skip()
+			if err != nil {
+				return err
+			}
+
+		}
+		decoder = originalDecoder
+	}
+	*v = sv
+	return nil
+}
+
+func awsRestxml_deserializeDocumentListOfRuleUnwrapped(v *[]types.Rule, decoder smithyxml.NodeDecoder) error {
+	var sv []types.Rule
+	if *v == nil {
+		sv = make([]types.Rule, 0)
+	} else {
+		sv = *v
+	}
+
+	switch {
+	default:
+		var mv types.Rule
+		t := decoder.StartEl
+		_ = t
+		nodeDecoder := smithyxml.WrapNodeDecoder(decoder.Decoder, t)
+		destAddr := &mv
+		if err := awsRestxml_deserializeDocumentRule(&destAddr, nodeDecoder); err != nil {
 			return err
 		}
 		mv = *destAddr


### PR DESCRIPTION
GetBucketLifecycleConfiguration response is a list, not a strucre.


Actual response

```xml
<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Rule><ID>lifecycle</ID><Status>Enabled</Status><Prefix>self-monitoring/</Prefix><Expiration><Days>1</Days></Expiration></Rule>
  <Rule><ID>loki</ID><Status>Enabled</Status><Prefix>loki_</Prefix><Expiration><Days>1</Days></Expiration></Rule>
  <Rule><ID>fake</ID><Status>Enabled</Status><Prefix>fake/</Prefix><Expiration><Days>1</Days></Expiration></Rule>
</LifecycleConfiguration>
```

